### PR TITLE
Added JavaScript-like `undefined` behaviour for missing attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ detox-test:
 travis-test: test
 
 test: env
-	.env/bin/py.test tests munch --doctest-modules
+	.env/bin/py.test test_munch.py munch --doctest-modules
 
 coverage-test: env
 	.env/bin/coverage run .env/bin/nosetests -w tests

--- a/README.md
+++ b/README.md
@@ -89,14 +89,33 @@ In addition, Munch instances will have a ``toYAML()`` method that returns the YA
 Finally, Munch converts easily and recursively to (``unmunchify()``, ``Munch.toDict()``) and from (``munchify()``, ``Munch.fromDict()``) a normal ``dict``, making it easy to cleanly serialize them in other formats.
 
 
+Undefined
+---------
+
+If you want something that behaves more closely to JavaScript with regards to
+missing keys, you can use ``UMunch``. It returns the special object
+``undefined`` for any attributes that are missing.
+
+````py
+>>> b = UMunch({'hello': 'world!'})
+>>> b.hello
+'world!'
+>>> b.foo
+undefined
+>>> b.foo == None
+True
+>>> b.foo is None
+False
+````
+
+
 Miscellaneous
 -------------
 
-* It is safe to ``import *`` from this module. You'll get: ``Munch``, ``munchify``, and ``unmunchify``.
+* It is safe to ``import *`` from this module. You'll get: ``Munch``, ``UMunch``, ``munchify``, ``unmunchify`` and ``undefined``.
 * Ample Tests. Just run ``pip install tox && tox`` from the project root.
 
 Feedback
 --------
 
 Open a ticket / fork the project on [GitHub](http://github.com/Infinidat/munch).
-

--- a/munch/__init__.py
+++ b/munch/__init__.py
@@ -236,6 +236,9 @@ class Undefined:
     def __bool__(self):
         return False
 
+    def __repr__(self):
+        return 'undefined'
+
 
 undefined = Undefined()
 

--- a/test_munch.py
+++ b/test_munch.py
@@ -1,6 +1,6 @@
 import json
 import pytest
-from munch import Munch, munchify, unmunchify
+from munch import Munch, munchify, unmunchify, UMunch, undefined
 
 
 def test_base():
@@ -171,3 +171,48 @@ def test_reserved_attributes(attrname):
         assert attr == {}
     else:
         assert callable(attr)
+
+
+def test_undefined():
+    assert undefined == None
+    assert undefined == undefined
+    assert undefined is undefined
+    assert undefined is not None
+
+
+def test_getattr_udef():
+    b = UMunch(bar='baz', lol={})
+    b.foo
+
+    assert b.bar == 'baz'
+    assert getattr(b, 'bar') == 'baz'
+    assert b['bar'] == 'baz'
+    assert b.lol is b['lol']
+    assert b.lol is getattr(b, 'lol')
+
+
+def test_setattr_udef():
+    b = UMunch(foo='bar', this_is='useful when subclassing')
+    assert hasattr(b.values, '__call__')
+
+    b.values = 'uh oh'
+    assert b.values == 'uh oh'
+
+    with pytest.raises(KeyError):
+        b['values']
+
+
+def test_delattr_udef():
+    b = UMunch(lol=42)
+    del b.lol
+
+    assert b.lol is undefined
+    with pytest.raises(KeyError):
+        b['lol']
+
+
+def test_munchify_udef():
+    b = munchify({'urmom': {'sez': {'what': 'what'}}}, UMunch)
+    assert b.urmom.sez.what == 'what'
+    assert b.urdad is undefined
+    assert b.urmom.sez.ni is undefined


### PR DESCRIPTION
Added a sub-class of `Munch`, `UMunch`, which returns `undefined` for missing attributes. You can use it like this:

```python
b = UMunch()
b.foo = 1
assert b.foo == 1
assert b.bar is undefined

# This does not raise an exception:
if b.bar == 2:
     ...
```

`munchify` has been changed to take an optional `factory` argument, which defaults to `Munch`. `Munch.fromDict` is now a class method, and returns the appropriate type (i.e. `UMunch.fromDict` returns a `UMunch` object). Tests have been updated.

The behaviour of `__getitem__` has not been changed. It could be made to return `undefined` for missing keys; I don't feel strongly about it either way.

I'm not sure if this feature is welcome, but I'm happy to discuss it.