### PR TITLE
Added DefaultMunch, which returns a special value for missing attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ detox-test:
 travis-test: test
 
 test: env
-	.env/bin/py.test tests munch --doctest-modules
+	.env/bin/py.test test_munch.py munch --doctest-modules
 
 coverage-test: env
 	.env/bin/coverage run .env/bin/nosetests -w tests

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Finally, Munch converts easily and recursively to (``unmunchify()``, ``Munch.toD
 Default Values
 --------------
 
-``DefaultMunch`` instances return some default value when an attribute is missing from the collection. Like ``collections.defaultdict``, the first argument is the value to use for missing keys:
+``DefaultMunch`` instances return a specific default value when an attribute is missing from the collection. Like ``collections.defaultdict``, the first argument is the value to use for missing keys:
 
 ````py
 >>> undefined = object()

--- a/README.md
+++ b/README.md
@@ -89,14 +89,39 @@ In addition, Munch instances will have a ``toYAML()`` method that returns the YA
 Finally, Munch converts easily and recursively to (``unmunchify()``, ``Munch.toDict()``) and from (``munchify()``, ``Munch.fromDict()``) a normal ``dict``, making it easy to cleanly serialize them in other formats.
 
 
+Default Values
+--------------
+
+``DefaultMunch`` instances return some default value when an attribute is missing from the collection. Like ``collections.defaultdict``, the first argument is the value to use for missing keys:
+
+````py
+>>> undefined = object()
+>>> b = DefaultMunch(undefined, {'hello': 'world!'})
+>>> b.hello
+'world!'
+>>> b.foo is undefined
+True
+````
+
+``DefaultMunch.fromDict()`` also takes the ``default`` argument:
+
+````py
+>>> undefined = object()
+>>> b = DefaultMunch.fromDict({'recursively': {'nested': 'value'}}, undefined)
+>>> b.recursively.nested == 'value'
+True
+>>> b.recursively.foo is undefined
+True
+````
+
+
 Miscellaneous
 -------------
 
-* It is safe to ``import *`` from this module. You'll get: ``Munch``, ``munchify``, and ``unmunchify``.
+* It is safe to ``import *`` from this module. You'll get: ``Munch``, ``DefaultMunch``, ``munchify`` and ``unmunchify``.
 * Ample Tests. Just run ``pip install tox && tox`` from the project root.
 
 Feedback
 --------
 
 Open a ticket / fork the project on [GitHub](http://github.com/Infinidat/munch).
-

--- a/munch/__init__.py
+++ b/munch/__init__.py
@@ -180,7 +180,7 @@ class Munch(dict):
 
             (*) Invertible so long as collection contents are each repr-invertible.
         """
-        return '%s(%s)' % (self.__class__.__name__, dict.__repr__(self))
+        return '{}({})'.format(self.__class__.__name__, dict.__repr__(self))
 
     def __dir__(self):
         return list(iterkeys(self))
@@ -251,7 +251,7 @@ class DefaultMunch(Munch):
         return type(self).fromDict(self, default=self.__default__)
 
     def __repr__(self):
-        return '%s(%r, %s)' % (
+        return '{}({!r}, {})'.format(
             type(self).__name__, self.__undefined__, dict.__repr__(self))
 
 

--- a/munch/__init__.py
+++ b/munch/__init__.py
@@ -180,7 +180,7 @@ class Munch(dict):
 
             (*) Invertible so long as collection contents are each repr-invertible.
         """
-        return '{}({})'.format(self.__class__.__name__, dict.__repr__(self))
+        return '{0}({1})'.format(self.__class__.__name__, dict.__repr__(self))
 
     def __dir__(self):
         return list(iterkeys(self))
@@ -251,7 +251,7 @@ class DefaultMunch(Munch):
         return type(self).fromDict(self, default=self.__default__)
 
     def __repr__(self):
-        return '{}({!r}, {})'.format(
+        return '{0}({1!r}, {2})'.format(
             type(self).__name__, self.__undefined__, dict.__repr__(self))
 
 

--- a/munch/__init__.py
+++ b/munch/__init__.py
@@ -187,8 +187,8 @@ class Munch(dict):
 
     __members__ = __dir__  # for python2.x compatibility
 
-    @classmethod
-    def fromDict(cls, d):
+    @staticmethod
+    def fromDict(d):
         """ Recursively transforms a dictionary into a Munch via copy.
 
             >>> b = Munch.fromDict({'urmom': {'sez': {'what': 'what'}}})
@@ -197,7 +197,7 @@ class Munch(dict):
 
             See munchify for more info.
         """
-        return munchify(d, cls)
+        return munchify(d, Munch)
 
     def copy(self):
         return Munch.fromDict(self)
@@ -242,9 +242,9 @@ class DefaultMunch(Munch):
         except KeyError:
             return self.__default__
 
-    @classmethod
-    def fromDict(cls, d, default=None):
-        return munchify(d, factory=lambda d_: cls(default, d_))
+    @staticmethod
+    def fromDict(d, default=None):
+        return munchify(d, factory=lambda d_: DefaultMunch(default, d_))
 
     def copy(self):
         return DefaultMunch.fromDict(self, default=self.__default__)

--- a/munch/__init__.py
+++ b/munch/__init__.py
@@ -187,8 +187,8 @@ class Munch(dict):
 
     __members__ = __dir__  # for python2.x compatibility
 
-    @staticmethod
-    def fromDict(d):
+    @classmethod
+    def fromDict(cls, d):
         """ Recursively transforms a dictionary into a Munch via copy.
 
             >>> b = Munch.fromDict({'urmom': {'sez': {'what': 'what'}}})
@@ -197,10 +197,10 @@ class Munch(dict):
 
             See munchify for more info.
         """
-        return munchify(d, Munch)
+        return munchify(d, cls)
 
     def copy(self):
-        return Munch.fromDict(self)
+        return type(self).fromDict(self)
 
 
 class DefaultMunch(Munch):
@@ -242,12 +242,13 @@ class DefaultMunch(Munch):
         except KeyError:
             return self.__default__
 
-    @staticmethod
-    def fromDict(d, default=None):
-        return munchify(d, factory=lambda d_: DefaultMunch(default, d_))
+    @classmethod
+    def fromDict(cls, d, default=None):
+        # pylint: disable=arguments-differ
+        return munchify(d, factory=lambda d_: cls(default, d_))
 
     def copy(self):
-        return DefaultMunch.fromDict(self, default=self.__default__)
+        return type(self).fromDict(self, default=self.__default__)
 
     def __repr__(self):
         return '%s(%r, %s)' % (

--- a/test_munch.py
+++ b/test_munch.py
@@ -1,6 +1,6 @@
 import json
 import pytest
-from munch import Munch, munchify, unmunchify
+from munch import DefaultMunch, Munch, munchify, unmunchify
 
 
 def test_base():
@@ -111,7 +111,11 @@ def test_fromDict():
 def test_copy():
     m = Munch(urmom=Munch(sez=Munch(what='what')))
     c = m.copy()
+    assert c is not m
+    assert c.urmom is not m.urmom
+    assert c.urmom.sez is not m.urmom.sez
     assert c.urmom.sez.what == 'what'
+    assert c == m
 
 
 def test_munchify():
@@ -171,3 +175,70 @@ def test_reserved_attributes(attrname):
         assert attr == {}
     else:
         assert callable(attr)
+
+
+def test_getattr_default():
+    b = DefaultMunch(bar='baz', lol={})
+    assert b.foo is None
+    assert b['foo'] is None
+
+    assert b.bar == 'baz'
+    assert getattr(b, 'bar') == 'baz'
+    assert b['bar'] == 'baz'
+    assert b.lol is b['lol']
+    assert b.lol is getattr(b, 'lol')
+
+    undefined = object()
+    b = DefaultMunch(undefined, bar='baz', lol={})
+    assert b.foo is undefined
+    assert b['foo'] is undefined
+
+
+def test_setattr_default():
+    b = DefaultMunch(foo='bar', this_is='useful when subclassing')
+    assert hasattr(b.values, '__call__')
+
+    b.values = 'uh oh'
+    assert b.values == 'uh oh'
+    assert b['values'] is None
+
+    assert b.__default__ is None
+    assert '__default__' not in b
+
+
+def test_delattr_default():
+    b = DefaultMunch(lol=42)
+    del b.lol
+
+    assert b.lol is None
+    assert b['lol'] is None
+
+
+def test_fromDict_default():
+    undefined = object()
+    b = DefaultMunch.fromDict({'urmom': {'sez': {'what': 'what'}}}, undefined)
+    assert b.urmom.sez.what == 'what'
+    assert b.urmom.sez.foo is undefined
+
+
+def test_copy_default():
+    undefined = object()
+    m = DefaultMunch.fromDict({'urmom': {'sez': {'what': 'what'}}}, undefined)
+    c = m.copy()
+    assert c is not m
+    assert c.urmom is not m.urmom
+    assert c.urmom.sez is not m.urmom.sez
+    assert c.urmom.sez.what == 'what'
+    assert c == m
+    assert c.urmom.sez.foo is undefined
+    assert c.urmom.sez.__undefined__ is undefined
+
+
+def test_munchify_default():
+    undefined = object()
+    b = munchify(
+        {'urmom': {'sez': {'what': 'what'}}},
+        lambda d: DefaultMunch(undefined, d))
+    assert b.urmom.sez.what == 'what'
+    assert b.urdad is undefined
+    assert b.urmom.sez.ni is undefined

--- a/test_munch.py
+++ b/test_munch.py
@@ -242,3 +242,9 @@ def test_munchify_default():
     assert b.urmom.sez.what == 'what'
     assert b.urdad is undefined
     assert b.urmom.sez.ni is undefined
+
+
+def test_repr_default():
+    b = DefaultMunch(foo=DefaultMunch(lol=True), ponies='are pretty!')
+    assert repr(b).startswith("DefaultMunch(None, {'")
+    assert "'ponies': 'are pretty!'" in repr(b)


### PR DESCRIPTION
Added a subclass of `Munch`: `DefaultMunch`, which returns a user-defined value when a requested key is not in the collection. The interface and behaviour is similar to `collections.defaultdict`, except that:

- Only a constant value is returned; there is no `default_factory` method.
- Retrieval of a missing value does not change the size of the collection.

`DefaultMuch.__default__` is a special attribute that won't be stored in the dictionary.

The construction signature is based on `defaultdict`, where the default value is the first argument:

```python
b = DefaultMunch(default, {})
```

This seemed cleaner than having a special keyword argument like `_default=foo` or so. However, the signature of `fromDict` is different, since it didn't already take any keyword arguments:

```python
b = DefaultMunch.fromDict({}, default=default)
```

This PR supercedes #15. To get similar behaviour to undefined, a sentinel can be used as the default value of `DefaultMunch`.