### PR TITLE
Implement the pickling interface

### DIFF
--- a/munch/__init__.py
+++ b/munch/__init__.py
@@ -185,6 +185,20 @@ class Munch(dict):
     def __dir__(self):
         return list(iterkeys(self))
 
+    def __getstate__(self):
+        """ Implement a serializable interface used for pickling.
+
+        See https://docs.python.org/3.6/library/pickle.html.
+        """
+        return self.toDict()
+
+    def __setstate__(self, state):
+        """ Implement a serializable interface used for pickling.
+
+        See https://docs.python.org/3.6/library/pickle.html.
+        """
+        self.__init__(state)
+
     __members__ = __dir__  # for python2.x compatibility
 
     @classmethod
@@ -241,6 +255,20 @@ class DefaultMunch(Munch):
             return super(DefaultMunch, self).__getitem__(k)
         except KeyError:
             return self.__default__
+
+    def __getstate__(self):
+        """ Implement a serializable interface used for pickling.
+
+        See https://docs.python.org/3.6/library/pickle.html.
+        """
+        return (self.__default__, self.toDict())
+
+    def __setstate__(self, state):
+        """ Implement a serializable interface used for pickling.
+
+        See https://docs.python.org/3.6/library/pickle.html.
+        """
+        self.__init__(*state)
 
     @classmethod
     def fromDict(cls, d, default=None):

--- a/munch/__init__.py
+++ b/munch/__init__.py
@@ -197,7 +197,8 @@ class Munch(dict):
 
         See https://docs.python.org/3.6/library/pickle.html.
         """
-        self.__init__(state)
+        self.clear()
+        self.update(state)
 
     __members__ = __dir__  # for python2.x compatibility
 
@@ -268,7 +269,10 @@ class DefaultMunch(Munch):
 
         See https://docs.python.org/3.6/library/pickle.html.
         """
-        self.__init__(*state)
+        self.clear()
+        default, state_dict = state
+        self.update(state_dict)
+        self.__default__ = default
 
     @classmethod
     def fromDict(cls, d, default=None):

--- a/test_munch.py
+++ b/test_munch.py
@@ -1,4 +1,5 @@
 import json
+import pickle
 import pytest
 from munch import DefaultMunch, Munch, munchify, unmunchify
 
@@ -63,6 +64,11 @@ def test_setattr():
 
     with pytest.raises(KeyError):
         b['values']
+
+
+def test_pickle():
+    b = DefaultMunch.fromDict({"a": "b"})
+    assert pickle.loads(pickle.dumps(b)) == b
 
 
 def test_delattr():
@@ -212,6 +218,11 @@ def test_delattr_default():
 
     assert b.lol is None
     assert b['lol'] is None
+
+
+def test_pickle_default():
+    b = DefaultMunch.fromDict({"a": "b"})
+    assert pickle.loads(pickle.dumps(b)) == b
 
 
 def test_fromDict_default():


### PR DESCRIPTION
Munch objects are not 'pickleable', which makes them difficult to use with multiprocessing (among other things). This implements the [`__getstate__`](https://docs.python.org/3.6/library/pickle.html#object.__getstate__) and [`__setstate__`](https://docs.python.org/3.6/library/pickle.html#object.__setstate__) interface for pickling.

(Reopenining of #23 on develop)