### PR TITLE
Build python wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
Wheels are the new standard of Python distribution and are intended to
replace eggs.

Closes #31
Signed-off-by: Paul Belanger <pabelanger@redhat.com>