### PR TITLE
Fix typo in travis-ci yaml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ deploy:
   user: vmalloc
   password:
     secure: m3sHHSCl+dhOKz1tT3kWGyLdLX7qUZvCxvnH2OadJZJ8ziG2X319IkqUZWolG6hSO7j4mFb9kK7PxFk81nClLUJpUrgQ4Uamui2qdgFOZBaUH5QVS8ZGvZ85/Faa3YBO4BqyMVY9SG8uNSCWvFFMY61rHBA0rOtS+ZtRyvCy2SQ=
+  distributions: sdist bdist_wheel
   on:
     tags: true
-    distributions: sdist bdist_wheel
     repo: Infinidat/munch


### PR DESCRIPTION
The distributions key was in the wrong sections, it should be under
deploy:

  https://docs.travis-ci.com/user/deployment/pypi/#Uploading-different-distributions

Signed-off-by: Paul Belanger <pabelanger@redhat.com>