### PR TITLE
Fix/namedtuple handling

### DIFF
--- a/munch/__init__.py
+++ b/munch/__init__.py
@@ -394,7 +394,8 @@ def unmunchify(x):
     if isinstance(x, dict):
         return dict((k, unmunchify(v)) for k, v in iteritems(x))
     elif isinstance(x, (list, tuple)):
-        return type(x)(unmunchify(v) for v in x)
+        type_factory = getattr(x, '_make', type(x))
+        return type_factory(unmunchify(v) for v in x)
     else:
         return x
 

--- a/munch/__init__.py
+++ b/munch/__init__.py
@@ -27,8 +27,7 @@ VERSION = tuple(map(int, __version__.split('.')))
 __all__ = ('Munch', 'munchify', 'DefaultMunch', 'DefaultFactoryMunch', 'unmunchify')
 
 
-from collections import defaultdict
-
+from collections import defaultdict, namedtuple
 
 from .python3_compat import *   # pylint: disable=wildcard-import
 
@@ -366,7 +365,11 @@ def munchify(x, factory=Munch):
     if isinstance(x, dict):
         return factory((k, munchify(v, factory)) for k, v in iteritems(x))
     elif isinstance(x, (list, tuple)):
-        return type(x)(munchify(v, factory) for v in x)
+        # namedtuples need special handling as they have a constructor that takes individual arguments and thus their
+        # '_make' method should be used instead (which takes a single iterable just like a normal tuple). There is no
+        # way to reliably identify a namedtuple, so this is just heuristic.
+        type_factory = getattr(x, '_make', type(x))
+        return type_factory(munchify(v, factory) for v in x)
     else:
         return x
 

--- a/test_munch.py
+++ b/test_munch.py
@@ -162,6 +162,12 @@ def test_unmunchify():
     assert sorted(unmunchify(b).items()) == [('foo', ['bar', {'lol': True}]), ('hello', 42), ('ponies', ('are pretty!', {'lies': 'are trouble!'}))]
 
 
+def test_unmunchify_namedtuple():
+    nt = namedtuple('nt', ['prop_a', 'prop_b'])
+    b = Munch(foo=Munch(lol=True), hello=nt(prop_a=42, prop_b='yop'), ponies='are pretty!')
+    assert sorted(unmunchify(b).items()) == [('foo', {'lol': True}), ('hello', nt(prop_a=42, prop_b='yop')), ('ponies', 'are pretty!')]
+
+
 def test_toJSON():
     b = Munch(foo=Munch(lol=True), hello=42, ponies='are pretty!')
     assert json.dumps(b) == b.toJSON()

--- a/test_munch.py
+++ b/test_munch.py
@@ -1,5 +1,7 @@
 import json
 import pickle
+from collections import namedtuple
+
 import pytest
 from munch import DefaultFactoryMunch, AutoMunch, DefaultMunch, Munch, munchify, unmunchify
 
@@ -139,6 +141,18 @@ def test_munchify():
     b = munchify({'lol': ('cats', {'hah': 'i win again'}), 'hello': [{'french': 'salut', 'german': 'hallo'}]})
     assert b.hello[0].french == 'salut'
     assert b.lol[1].hah == 'i win again'
+
+def test_munchify_with_namedtuple():
+    nt = namedtuple('nt', ['prop_a', 'prop_b'])
+
+    b = munchify({'top': nt('in named tuple', 3)})
+    assert b.top.prop_a == 'in named tuple'
+    assert b.top.prop_b == 3
+
+    b = munchify({'top': {'middle': nt(prop_a={'leaf': 'should be munchified'}, prop_b={'leaf': 'should be munchified'})}})
+    assert b.top.middle.leaf == 'should be munchified'
+    assert b.top.prop_a.middle.leaf == 'should be munchified'
+    assert b.top.prop_b.middle.leaf == 'should be munchified'
 
 
 def test_unmunchify():

--- a/test_munch.py
+++ b/test_munch.py
@@ -150,9 +150,8 @@ def test_munchify_with_namedtuple():
     assert b.top.prop_b == 3
 
     b = munchify({'top': {'middle': nt(prop_a={'leaf': 'should be munchified'}, prop_b={'leaf': 'should be munchified'})}})
-    assert b.top.middle.leaf == 'should be munchified'
-    assert b.top.prop_a.middle.leaf == 'should be munchified'
-    assert b.top.prop_b.middle.leaf == 'should be munchified'
+    assert b.top.middle.prop_a.leaf == 'should be munchified'
+    assert b.top.middle.prop_b.leaf == 'should be munchified'
 
 
 def test_unmunchify():


### PR DESCRIPTION
Fixed namedtuple handling in munchify and unmunchify. Current version has a bug where if you have a namedtuple in the hierarchy you are trying to munchify (or unmunchify) the process will break as namedtuples have a different constructor than ordinary tuples. (The former expects distinct arguments the latter expects an iterable.)