### PR TITLE
Fix DefaultMunch/DefaultFactoryMunch return value for get method (fixes #53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 Next Version
 ------------
+* Fix return value of DefaultMunch and DefaultFactoryMunch's get method (fixes [#53](https://github.com/Infinidat/munch/issues/53))
 
 2.4.0 (2019-10-29)
 ------------------

--- a/munch/__init__.py
+++ b/munch/__init__.py
@@ -238,10 +238,9 @@ class Munch(dict):
         """
         D.get(k[,d]) -> D[k] if k in D, else d.  d defaults to None.
         """
-        try:
-            return self[k]
-        except KeyError:
+        if k not in self:
             return d
+        return self[k]
 
     def setdefault(self, k, d=None):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import munch
 
 
 @pytest.fixture(name='yaml')
@@ -9,3 +10,12 @@ def yaml_module():
     except ImportError:
         pass
     pytest.skip("Module 'PyYAML' is required")
+
+
+@pytest.fixture(params=[munch.Munch, munch.AutoMunch, munch.DefaultMunch, munch.DefaultFactoryMunch])
+def munch_obj(request):
+    cls = request.param
+    args = tuple()
+    if cls == munch.DefaultFactoryMunch:
+        args = args + (lambda: None,)
+    return cls(*args, hello="world", number=5)

--- a/tests/test_munch.py
+++ b/tests/test_munch.py
@@ -533,3 +533,7 @@ def test_getitem_dunder_for_subclass():
     assert custom_munch.a == 42
     assert custom_munch.get('b') == 42
     assert custom_munch.copy() == Munch(a=42, b=42)
+
+
+def test_get_default_value(munch_obj):
+    assert munch_obj.get("fake_key", "default_value") == "default_value"


### PR DESCRIPTION
Commit 10c726f847b3b7fb6d666809ab5b65f81b966192 added a bug which cause
``DefaultMunch`` and ``DefaultFactoryMunch`` to ignore the ``default_value``
parameter of get method.