### PR TITLE
replace pkg_resources with importlib.metadata

### DIFF
--- a/munch/__init__.py
+++ b/munch/__init__.py
@@ -21,11 +21,20 @@
     converted via Munch.to/fromDict().
 """
 
-import pkg_resources
-
 from .python3_compat import iterkeys, iteritems, Mapping, u
 
-__version__ = pkg_resources.get_distribution('munch').version
+try:
+    # For python 3.8 and later
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    # For everyone else
+    import importlib_metadata
+try:
+    __version__ = importlib_metadata.version(__name__)
+except importlib_metadata.PackageNotFoundError:
+    # package is not installed
+    pass
+
 VERSION = tuple(map(int, __version__.split('.')[:3]))
 
 __all__ = ('Munch', 'munchify', 'DefaultMunch', 'DefaultFactoryMunch', 'RecursiveMunch', 'unmunchify')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 six
+importlib_metadata>=1.7.0;python_version<'3.8' # Apache-2.0


### PR DESCRIPTION
Importing pkg_resources has a side-effect of scanning every installed
distribution on sys.path to load the metadata, especially the entry
points defined in the packages. This can have a significant
launch-time cost for command line applications when there are a lot of
distributions to scan.

Since munch is only using pkg_resources to find the version of the
installed package, pkg_resources can be replaced with
importlib.metadata. The implementation in the new library is
significantly faster because it goes immediately to the metadata file
for the requested distribution, instead of scanning all of them. There
are also no import-time side-effects.

importlib.metadata is a new standard library module starting with
python 3.8. For earlier versions, a compatible library has been
released to PyPI as 'importlib_metadata'. This change adds the new
dependency with a qualifier so that it is only applied to older
versions of python, and then updates the places that were importing
pkg_resources to look for the different versions of the new library
instead.