### PR TITLE
#75 Allow importing even when VERSION read fails

### DIFF
--- a/munch/__init__.py
+++ b/munch/__init__.py
@@ -35,7 +35,10 @@ except importlib_metadata.PackageNotFoundError:
     # package is not installed
     pass
 
-VERSION = tuple(map(int, __version__.split('.')[:3]))
+try:
+    VERSION = tuple(map(int, __version__.split('.')[:3]))
+except ValueError:
+    VERSION = (0, 0, 0)
 
 __all__ = ('Munch', 'munchify', 'DefaultMunch', 'DefaultFactoryMunch', 'RecursiveMunch', 'unmunchify')
 

--- a/munch/__init__.py
+++ b/munch/__init__.py
@@ -33,7 +33,7 @@ try:
     __version__ = importlib_metadata.version(__name__)
 except importlib_metadata.PackageNotFoundError:
     # package is not installed
-    pass
+    __version__ = "0.0.0"
 
 try:
     VERSION = tuple(map(int, __version__.split('.')[:3]))


### PR DESCRIPTION
Sometimes the contents of `importlib_metadata.version(__name__)` do not only contain numbers. Sometimes `importlib_metadata.version(__name__)` fails completely.

I observed that on pipenv/Google AppEngine Python 2.7.

This PR sets VERSION to (0,0,0) in that case, allowing usage of Munch.

fix #75