### PR TITLE
Create CI configurations with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Upgrade build tools
-      run: pip install --upgrade pip build wheel setuptools
+    - name: Upgrade build tools and pytest
+      run: pip install --upgrade pip build wheel setuptools pytest
     - name: Build distributions
       run: python -m build
     - name: Test with Pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: Build and Test
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+       fail-fast: false
+       matrix:
+         os: [ubuntu-latest]
+         py: ["3.7", "3.8", "3.9", "3.10"]
+         include:
+           - os: macos-latest
+             python-version: "3.10"
+           - os: windows-latest
+             python-version: "3.10"
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Upgrade build tools
+      run: pip install --upgrade pip build wheel setuptools
+    - name: Build distributions
+      run: python -m build
+    - name: Test with Pytest
+      run: pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
        fail-fast: false
        matrix:
          os: [ubuntu-latest]
-         py: ["3.7", "3.8", "3.9", "3.10"]
+         python-version: ["3.7", "3.8", "3.9", "3.10"]
          include:
            - os: macos-latest
              python-version: "3.10"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Upgrade build tools and pytest
       run: pip install --upgrade pip build wheel setuptools pytest
+    - name: Install dependencies
+      run: pip install -r requirements.txt
     - name: Build distributions
       run: python -m build
     - name: Test with Pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
        fail-fast: false
        matrix:
          os: [ubuntu-latest]
-         python-version: ["3.7", "3.8", "3.9", "3.10"]
+         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
          include:
            - os: macos-latest
              python-version: "3.10"


### PR DESCRIPTION
Creates a CI configuration with GitHub Actions that builds and tests munch on Python 3.7 to 3.10 and Ubuntu, Windows and macOS.