### PR TITLE
Require Python >=3.6 and upgrade syntax

### DIFF
--- a/munch/__init__.py
+++ b/munch/__init__.py
@@ -202,7 +202,7 @@ class Munch(dict):
 
             (*) Invertible so long as collection contents are each repr-invertible.
         """
-        return '{0}({1})'.format(self.__class__.__name__, dict.__repr__(self))
+        return '{}({})'.format(self.__class__.__name__, dict.__repr__(self))
 
     def __dir__(self):
         return list(iterkeys(self))
@@ -271,7 +271,7 @@ class AutoMunch(Munch):
         """
         if isinstance(v, Mapping) and not isinstance(v, (AutoMunch, Munch)):
             v = munchify(v, AutoMunch)
-        super(AutoMunch, self).__setattr__(k, v)
+        super().__setattr__(k, v)
 
 
 class DefaultMunch(Munch):
@@ -290,13 +290,13 @@ class DefaultMunch(Munch):
             args = args[1:]
         else:
             default = None
-        super(DefaultMunch, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.__default__ = default
 
     def __getattr__(self, k):
         """ Gets key if it exists, otherwise returns the default value."""
         try:
-            return super(DefaultMunch, self).__getattr__(k)
+            return super().__getattr__(k)
         except AttributeError:
             return self.__default__
 
@@ -304,12 +304,12 @@ class DefaultMunch(Munch):
         if k == '__default__':
             object.__setattr__(self, k, v)
         else:
-            super(DefaultMunch, self).__setattr__(k, v)
+            super().__setattr__(k, v)
 
     def __getitem__(self, k):
         """ Gets key if it exists, otherwise returns the default value."""
         try:
-            return super(DefaultMunch, self).__getitem__(k)
+            return super().__getitem__(k)
         except KeyError:
             return self.__default__
 
@@ -339,7 +339,7 @@ class DefaultMunch(Munch):
         return type(self).fromDict(self, default=self.__default__)
 
     def __repr__(self):
-        return '{0}({1!r}, {2})'.format(
+        return '{}({!r}, {})'.format(
             type(self).__name__, self.__undefined__, dict.__repr__(self))
 
 
@@ -358,7 +358,7 @@ class DefaultFactoryMunch(Munch):
     """
 
     def __init__(self, default_factory, *args, **kwargs):
-        super(DefaultFactoryMunch, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.default_factory = default_factory
 
     @classmethod
@@ -371,14 +371,14 @@ class DefaultFactoryMunch(Munch):
 
     def __repr__(self):
         factory = self.default_factory.__name__
-        return '{0}({1}, {2})'.format(
+        return '{}({}, {})'.format(
             type(self).__name__, factory, dict.__repr__(self))
 
     def __setattr__(self, k, v):
         if k == 'default_factory':
             object.__setattr__(self, k, v)
         else:
-            super(DefaultFactoryMunch, self).__setattr__(k, v)
+            super().__setattr__(k, v)
 
     def __missing__(self, k):
         self[k] = self.default_factory()
@@ -403,7 +403,7 @@ class RecursiveMunch(DefaultFactoryMunch):
     """
 
     def __init__(self, *args, **kwargs):
-        super(RecursiveMunch, self).__init__(RecursiveMunch, *args, **kwargs)
+        super().__init__(RecursiveMunch, *args, **kwargs)
 
     @classmethod
     def fromDict(cls, d):

--- a/munch/__init__.py
+++ b/munch/__init__.py
@@ -202,7 +202,7 @@ class Munch(dict):
 
             (*) Invertible so long as collection contents are each repr-invertible.
         """
-        return '{}({})'.format(self.__class__.__name__, dict.__repr__(self))
+        return f'{self.__class__.__name__}({dict.__repr__(self)})'
 
     def __dir__(self):
         return list(iterkeys(self))
@@ -339,8 +339,7 @@ class DefaultMunch(Munch):
         return type(self).fromDict(self, default=self.__default__)
 
     def __repr__(self):
-        return '{}({!r}, {})'.format(
-            type(self).__name__, self.__undefined__, dict.__repr__(self))
+        return f'{type(self).__name__}({self.__undefined__!r}, {dict.__repr__(self)})'
 
 
 class DefaultFactoryMunch(Munch):
@@ -371,8 +370,7 @@ class DefaultFactoryMunch(Munch):
 
     def __repr__(self):
         factory = self.default_factory.__name__
-        return '{}({}, {})'.format(
-            type(self).__name__, factory, dict.__repr__(self))
+        return f'{type(self).__name__}({factory}, {dict.__repr__(self)})'
 
     def __setattr__(self, k, v):
         if k == 'default_factory':

--- a/munch/python3_compat.py
+++ b/munch/python3_compat.py
@@ -3,4 +3,4 @@ try:
     from collections.abc import Mapping  # pylint: disable=unused-import
 except ImportError:
     # Legacy Python
-    from collections import Mapping  # pylint: disable=unused-import
+    from collections.abc import Mapping  # pylint: disable=unused-import

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,17 +5,18 @@ classifiers =
     Intended Audience :: Developers
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Software Development
     Topic :: Software Development :: Libraries
     Topic :: Utilities
     License :: OSI Approved :: MIT License
 summary = A dot-accessible dictionary (a la JavaScript objects)
-description-file =
-    README.md
+description-file = README.md
 description-content-type = text/markdown
 license = MIT
 author = Rotem Yaari
@@ -24,10 +25,8 @@ url = https://github.com/Infinidat/munch
 
 [extras]
 testing =
-    astroid~=1.5.3; python_version=='2.7'
-    astroid>=2.0; python_version >= '3.4'
-    pylint~=1.7.2; python_version=='2.7'
-    pylint~=2.3.1; python_version >= '3.4'
+    astroid>=2.0
+    pylint~=2.3.1
     pytest
     coverage
 yaml =

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,9 @@ from setuptools import setup
 
 
 setup(
-    setup_requires=['pbr>=3.0', 'setuptools>=17.1'],
+    setup_requires=['pbr>=3.0', 'setuptools>=61'],
     pbr=True,
     long_description_content_type='text/markdown; charset=UTF-8',
     keywords=['munch', 'dict', 'mapping', 'container', 'collection'],
+    python_requires=">=3.6",
 )

--- a/tests/test_munch.py
+++ b/tests/test_munch.py
@@ -520,7 +520,7 @@ def test_setitem_dunder_for_subclass():
     def test_class(cls, *args):
         class CustomMunch(cls):
             def __setitem__(self, k, v):
-                super(CustomMunch, self).__setitem__(k, [v] * 2)
+                super().__setitem__(k, [v] * 2)
         custom_munch = CustomMunch(*args, a='foo')
         assert custom_munch.a == ['foo', 'foo']
         regular_dict = {}

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import doctest
 import os
 import sys


### PR DESCRIPTION
Drop Python 2 and Python 3.5 and lower support, require at least Python 3.6.

Python 3.6 is already end-of-life, but relatively easy to maintain. It allows for using f-strings and other modern functions. Python 3.7 is currently the oldest supported Python version.

This PR also upgrade Python syntax to 3.6, using [pyupgrade](https://github.com/asottile/pyupgrade) with `--py36-plus`.

This allows to for new development to use modern Python syntax and features. Of course older releases can still be used with older Python versions.