### PR TITLE
CI: Add pylint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,11 @@ jobs:
       run: python -m build
     - name: Test with Pytest
       run: pytest
+
+  pylint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+    - run: pip install pylint
+    - run: pylint munch setup.py tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,5 +40,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
-    - run: pip install pylint
+    # Install the testing dependencies from setup.cfg, including pylint
+    - run: pip install .[testing]
     - run: pylint munch setup.py tests


### PR DESCRIPTION
Add a job to the CI which lints the code using the pylint version specified in setup.cfg.